### PR TITLE
use tab load event instead of ajax global

### DIFF
--- a/AjaxExample/AjaxExample.csproj
+++ b/AjaxExample/AjaxExample.csproj
@@ -20,6 +20,7 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <WebGreaseLibPath>..\packages\WebGrease.1.5.2\lib</WebGreaseLibPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,6 +40,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Antlr3.Runtime">
+      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <Private>True</Private>
@@ -74,6 +78,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Mvc.5.1.1\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Optimization">
+      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll</HintPath>
@@ -106,6 +113,9 @@
     <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
+    </Reference>
+    <Reference Include="WebGrease">
+      <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -254,7 +264,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>True</UseIIS>
+          <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>59802</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>

--- a/AjaxExample/Content/scripts/app.js
+++ b/AjaxExample/Content/scripts/app.js
@@ -1,52 +1,68 @@
-﻿require(['require', 'jquery', 'controllers/summary', 'controllers/details'], function (require) {
+﻿// define defines a module
+// require should only be on a page;  it consumes one
+define([
+    'require',
+    'jquery',
+    'jquery-ui',
+    './legacyapp',
+    './controllers/summary',
+    './controllers/details'
+],
+function (
+    require,
+    $
+) {
     'use strict';
-
-    var $ = require('jquery');
-    var SummaryController = require('controllers/summary');
-    var DetailsController = require('controllers/details');
-
+    
     var App = function () {
-        this.summaryController = new SummaryController('.js-summary-container');
-        this.detailsController = new DetailsController('.js-details-container');
-    }
+        this._tabs = $('#tabs');
+    };
 
-    App.prototype.init = function() {
+    App.prototype.init = function () {
+        this.controllers = {};
         this.setUpHandlers()
             .bind();
     };
 
     App.prototype.setUpHandlers = function () {
-        this.summaryLoadedHandler = $.proxy(this.summaryLoaded, this);
-        this.detailsLoadedHandler = $.proxy(this.detailsLoaded, this);
-
+        this.loadHandler = $.proxy(this.tabLoaded, this);
         return this;
+    };
+
+    App.prototype.tabLoaded = function (event, ui) {
+        console.log(ui.tab.text(), 'loaded');
+
+        // grab the link that was just clicked
+        var href = ui.tab.find('a').attr('href');
+
+        /* one way... 
+        var controllerName = href.substr(href.lastIndexOf('/') + 1);
+        var controller = require('./controllers/' + controllerName);
+        */
+
+        // require the related (defined) controller class
+        var controllerModule = href.replace(/\/home/, './controllers');
+        // instantiates, (inits) builds children if necessary
+        var controllerInstance = this.getController(controllerModule, ui.panel);
+        controllerInstance.render();
     };
 
     App.prototype.bind = function () {
-        $(document).on('ajaxComplete', this.summaryLoadedHandler);
-        $(document).on('ajaxComplete', this.detailsLoadedHandler);
-
+        this._tabs.tabs('option', 'load', this.loadHandler);
         return this;
     };
 
-    App.prototype.summaryLoaded = function(evt, xhr, settings) {
-        this.handleLoadEvent(settings, /^\/home\/summary/i, this.summaryController, this.summaryLoadedHandler);
-    };
-
-    App.prototype.detailsLoaded = function(evt, xhr, settings) {
-        this.handleLoadEvent(settings, /^\/home\/details/i, this.detailsController, this.detailsLoadedHandler);
-    };
-
-    App.prototype.handleLoadEvent = function(settings, urlRegex, controller, handler) {
-        if (settings.url.match(urlRegex)) {
-            $(document).off('ajaxComplete', handler);
-            setTimeout(function () {
-                // let the tab finish loading first, then initialize the controller
-                // the timeout value of 0 let's the tab thread complete
-                // then executes this immediately (or at least that's the theory)
-                controller.init();
-            }, 0);
+    App.prototype.getController = function(module, contents) {
+        // check the cache
+        if (!this.controllers[module]) {
+            // require it; 
+            var controller = require(module);
+            // cache it;
+            this.controllers[module] =
+                // instantiate it; call init
+                new controller(contents).init();
         }
+        return this.controllers[module];
     };
 
     $(function () {

--- a/AjaxExample/Content/scripts/controllers/details.js
+++ b/AjaxExample/Content/scripts/controllers/details.js
@@ -7,7 +7,10 @@
 
     details.prototype.init = function () {
         this.setupHandlers()
-            .bind();
+            .bind()
+            .createChildren();
+
+        return this;
     };
 
     details.prototype.setupHandlers = function () {
@@ -17,6 +20,29 @@
     details.prototype.bind = function () {
         this.$container = $(this.selector);
         return this;
+    };
+
+    details.prototype.createChildren = function () {
+        this.$someDetails = $('<ul>');
+        var $listItems = $('<li>');
+
+        var textItems = [
+            'these',
+            'are',
+            'details'
+        ];
+
+        textItems.forEach(function (text) {
+            var $item = $('<li>');
+            $listItems.append($item);
+            $item.text(text);
+        });
+
+        this.$someDetails.append($listItems);
+    };
+
+    details.prototype.render = function() {
+        this.$container.append(this.$someDetails);
     };
 
     return details;

--- a/AjaxExample/Content/scripts/controllers/summary.js
+++ b/AjaxExample/Content/scripts/controllers/summary.js
@@ -1,22 +1,35 @@
-﻿define(function(require) {
-    var $ = require('jquery');
-
+﻿define([
+    'require',
+    'jquery'
+],
+function (require, $) {
     var summary = function (selector) {
         this.selector = selector;
     };
 
     summary.prototype.init = function () {
         this.setupHandlers()
-            .bind();
+            .bind()
+            .createChildren();
+        return this;
     };
 
-    summary.prototype.setupHandlers = function() {
+    summary.prototype.setupHandlers = function () {
         return this;
     };
 
     summary.prototype.bind = function () {
         this.$container = $(this.selector);
         return this;
+    };
+
+    summary.prototype.createChildren = function () {
+        this.someRandomChild = $('<div>');
+        this.someRandomChild.text(Math.random(10, 100));
+    };
+
+    summary.prototype.render = function() {
+        this.$container.append(this.someRandomChild);
     };
 
     return summary;

--- a/AjaxExample/Content/scripts/legacyapp.js
+++ b/AjaxExample/Content/scripts/legacyapp.js
@@ -1,4 +1,10 @@
-﻿require(['require', 'jquery', 'bootstrap', 'jquery-ui', 'jquery-validate-unobtrusive'], function (require) {
+﻿define([
+    'require',
+    'jquery',
+    'bootstrap',
+    'jquery-ui',
+    'jquery-validate-unobtrusive'
+], function (require, $) {
     'use strict';
 
     var $ = require('jquery');

--- a/AjaxExample/Views/Home/Index.cshtml
+++ b/AjaxExample/Views/Home/Index.cshtml
@@ -4,7 +4,9 @@
 
 @section scripts
 {
-    <script type="text/javascript" src="@Url.Content("~/content/scripts/app.js")"></script>
+    <script>
+        require(['./app']);
+    </script>
 }
 <div id="tabs">
     <ul>

--- a/AjaxExample/Views/Shared/_Layout.cshtml
+++ b/AjaxExample/Views/Shared/_Layout.cshtml
@@ -49,7 +49,6 @@
         <script type="text/javascript" src="@Url.Content("~/scripts/require.js")"></script>
         @* Load configuration synchronously so that it's done before including the application *@
         <script type="text/javascript" src="@Url.Content("~/scripts/main.js")"></script>
-        <script type="text/javascript" src="@Url.Content("~/content/scripts/legacyapp.js")"></script>
         @RenderSection("scripts", required: false)
     </body>
 </html>

--- a/AjaxExample/Web.config
+++ b/AjaxExample/Web.config
@@ -1,54 +1,62 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.5"/>
-    <httpRuntime targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" />
   </system.web>
 
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/AjaxExample/packages.config
+++ b/AjaxExample/packages.config
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="bootstrap" version="3.1.1" targetFramework="net45" />
   <package id="jQuery" version="2.1.0" targetFramework="net45" />
   <package id="jQuery.UI.Combined" version="1.10.4" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
@@ -15,4 +17,5 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="RequireJS" version="2.1.11" targetFramework="net45" />
+  <package id="WebGrease" version="1.5.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
also implemented some dom logic for example of caching contents for tabs (if they are reloaded when switching)
note, alternatively you could grab the tab create event and grab the jqXhr instance member's promise, and attach handlers to it's when
